### PR TITLE
Add auto update for VBA modules from SharePoint on workbook open

### DIFF
--- a/MICROSOFT_EXCEL_OBJECTS/ThisWorkbook.cls
+++ b/MICROSOFT_EXCEL_OBJECTS/ThisWorkbook.cls
@@ -39,14 +39,13 @@ error100:
 End Sub
 
 Private Sub Workbook_Open()
+Call updates
 
 'save the standard protected range
 Call SelectLockedCells
 
 'initiate
 Call start
-
-'Call updates
 
 End Sub
 

--- a/MODULES/m_update.bas
+++ b/MODULES/m_update.bas
@@ -1,7 +1,120 @@
 Attribute VB_Name = "m_update"
 
-
 Sub updates()
+On Error GoTo updatefail
 
+    Dim moduleURL As String
+    Dim objectURL As String
+    Dim tempFolder As String
+    Dim vbComp As Object
+    Dim tmpFile As String
+    Dim fileURL As String
+
+    moduleURL = "https://halyardinc-my.sharepoint.com/:f:/r/personal/abel_halyard_ca/Documents/Documents/Abel/Programing/GitHub/VBA/MODULES/"
+    objectURL = "https://halyardinc-my.sharepoint.com/:f:/r/personal/abel_halyard_ca/Documents/Documents/Abel/Programing/GitHub/VBA/MICROSOFT_EXCEL_OBJECTS/"
+    tempFolder = Environ("TEMP") & "\"
+
+    For Each vbComp In ThisWorkbook.VBProject.VBComponents
+
+        fileURL = ""
+        tmpFile = ""
+
+        Select Case vbComp.Type
+            Case 1
+                If vbComp.Name <> "m_update" Then
+                    fileURL = moduleURL & vbComp.Name & ".bas"
+                    tmpFile = tempFolder & vbComp.Name & ".bas"
+                    If DownloadFile(fileURL, tmpFile) Then
+                        If Not CodeMatchesFile(vbComp, tmpFile) Then
+                            ThisWorkbook.VBProject.VBComponents.Remove vbComp
+                            ThisWorkbook.VBProject.VBComponents.Import tmpFile
+                        End If
+                    Else
+                        GoTo updatefail
+                    End If
+                End If
+            Case 100
+                fileURL = objectURL & vbComp.Name & ".cls"
+                tmpFile = tempFolder & vbComp.Name & ".cls"
+                If DownloadFile(fileURL, tmpFile) Then
+                    If Not CodeMatchesFile(vbComp, tmpFile) Then
+                        vbComp.CodeModule.DeleteLines 1, vbComp.CodeModule.CountOfLines
+                        vbComp.CodeModule.AddFromFile tmpFile
+                    End If
+                Else
+                    GoTo updatefail
+                End If
+        End Select
+
+    Next vbComp
+
+    Exit Sub
+
+updatefail:
+    MsgBox "Unable to retrieve latest code. Please contact abel@halyard.ca", vbCritical
+    Application.DisplayAlerts = False
+    ThisWorkbook.Close SaveChanges:=False
+    End
 
 End Sub
+
+Private Function DownloadFile(ByVal url As String, ByVal dest As String) As Boolean
+On Error GoTo errHandler
+
+    Dim http As Object
+    Dim stream As Object
+
+    Set http = CreateObject("MSXML2.XMLHTTP")
+    http.Open "GET", url, False
+    http.send
+
+    If http.Status = 200 Then
+        Set stream = CreateObject("ADODB.Stream")
+        stream.Type = 1
+        stream.Open
+        stream.Write http.responseBody
+        stream.SaveToFile dest, 2
+        stream.Close
+        Set stream = Nothing
+        Set http = Nothing
+        DownloadFile = True
+    Else
+        DownloadFile = False
+    End If
+
+    Exit Function
+
+errHandler:
+    DownloadFile = False
+
+End Function
+
+Private Function CodeMatchesFile(vbComp As Object, ByVal filePath As String) As Boolean
+    Dim fileCode As String
+    Dim currentCode As String
+
+    fileCode = GetCodeFromFile(filePath)
+    currentCode = vbComp.CodeModule.Lines(1, vbComp.CodeModule.CountOfLines)
+
+    CodeMatchesFile = (StrComp(currentCode, fileCode, vbBinaryCompare) = 0)
+End Function
+
+Private Function GetCodeFromFile(ByVal filePath As String) As String
+    Dim fso As Object
+    Dim ts As Object
+    Dim content As String
+    Dim startPos As Long
+
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Set ts = fso.OpenTextFile(filePath, 1)
+    content = ts.ReadAll
+    ts.Close
+
+    startPos = InStr(1, content, "Attribute VB_Name")
+    If startPos > 0 Then
+        content = Mid$(content, startPos)
+    End If
+
+    GetCodeFromFile = content
+End Function
+


### PR DESCRIPTION
## Summary
- Update workbook to fetch latest VBA modules from SharePoint on startup
- Fetch remote module and object code and replace local versions
- Skip importing modules when downloaded code matches existing workbook code

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689bc397255c8327be70b7e278010bd2