### PR TITLE
Add SharePoint-aware update process with user locks

### DIFF
--- a/MICROSOFT_EXCEL_OBJECTS/ThisWorkbook.cls
+++ b/MICROSOFT_EXCEL_OBJECTS/ThisWorkbook.cls
@@ -34,6 +34,12 @@ Private Sub Workbook_Open()
     Dim versionName As Name
     Dim version As Long
 
+    If IsUpdatingInProgress() Then
+        MsgBox "The workbook is currently being updated. Please try again later.", vbExclamation
+        ThisWorkbook.Close SaveChanges:=False
+        Application.Quit
+    End If
+
     latestVersion = GetLatestVersion()
 
     On Error Resume Next
@@ -46,14 +52,20 @@ Private Sub Workbook_Open()
     On Error GoTo 0
 
     If latestVersion > 0 And latestVersion > version Then
-        MsgBox "A new version (" & latestVersion & ") is available. " & _
-               "The workbook will close and reopen with the update.", vbInformation
-        updates
-        Exit Sub
+        If IsOnlyUser() Then
+            MsgBox "A new version (" & latestVersion & ") is available. " & _
+                   "The workbook will close and reopen with the update.", vbInformation
+            updates
+            Exit Sub
+        Else
+            MsgBox "A new version (" & latestVersion & ") is available and will be installed " & _
+                   "when all other users close the workbook.", vbInformation
+        End If
     End If
 
     Call SelectLockedCells
     Call start
+    ShowUpdateInfoOnce
 
 'HOLA-HOLA-HOLA-HOLA
 

--- a/vba_update.vbs
+++ b/vba_update.vbs
@@ -4,6 +4,18 @@ If args.Count = 0 Then
   WScript.Quit 1
 End If
 wbPath = args(0)
+Set fso = CreateObject("Scripting.FileSystemObject")
+lockPath = fso.GetParentFolderName(wbPath) & "\\update.lock"
+If fso.FileExists(lockPath) Then
+  WScript.Echo "Update already in progress."
+  WScript.Quit 1
+End If
+Set lockFile = fso.CreateTextFile(lockPath, True)
+lockFile.Close
+moduleBase = "https://halyardinc-my.sharepoint.com/:u:/r/personal/abel_halyard_ca/Documents/Documents/Abel/Programing/GitHub/VBA/MEL/MODULES/"
+objectBase = "https://halyardinc-my.sharepoint.com/:u:/r/personal/abel_halyard_ca/Documents/Documents/Abel/Programing/GitHub/VBA/MEL/MICROSOFT_EXCEL_OBJECTS/"
+tempPath = fso.BuildPath(fso.GetSpecialFolder(2), "vba_update")
+If Not fso.FolderExists(tempPath) Then fso.CreateFolder(tempPath)
 On Error Resume Next
 Set xl = CreateObject("Excel.Application")
 If Err.Number <> 0 Then
@@ -25,26 +37,25 @@ If Err.Number <> 0 Then
   CleanUp
   WScript.Quit 1
 End If
-modulePath="C:\Users\Abel\OneDrive - Halyard Inc\Documents\Abel\Programing\GitHub\VBA\MEL\MODULES\"
-objectPath="C:\Users\Abel\OneDrive - Halyard Inc\Documents\Abel\Programing\GitHub\VBA\MEL\MICROSOFT_EXCEL_OBJECTS\"
-Set fso=CreateObject("Scripting.FileSystemObject")
 For Each vbComp In wb.VBProject.VBComponents
   Select Case vbComp.Type
     Case 1
-      compName=vbComp.Name
-      filePath=modulePath & compName & ".bas"
-      If fso.FileExists(filePath) Then
+      compName = vbComp.Name
+      url = moduleBase & compName & ".bas"
+      tempFile = fso.BuildPath(tempPath, compName & ".bas")
+      If Download(url, tempFile) Then
         wb.VBProject.VBComponents.Remove vbComp
-        Set vbComp=wb.VBProject.VBComponents.Import(filePath)
-        vbComp.Name=compName
+        Set vbComp = wb.VBProject.VBComponents.Import(tempFile)
+        vbComp.Name = compName
       End If
     Case 100
-      filePath=objectPath & vbComp.Name & ".cls"
-      If fso.FileExists(filePath) Then
-        If vbComp.CodeModule.CountOfLines>0 Then
+      url = objectBase & vbComp.Name & ".cls"
+      tempFile = fso.BuildPath(tempPath, vbComp.Name & ".cls")
+      If Download(url, tempFile) Then
+        If vbComp.CodeModule.CountOfLines > 0 Then
           vbComp.CodeModule.DeleteLines 1, vbComp.CodeModule.CountOfLines
         End If
-        vbComp.CodeModule.AddFromFile filePath
+        vbComp.CodeModule.AddFromFile tempFile
       End If
   End Select
 Next
@@ -58,9 +69,35 @@ xl.Run "'" & wb.Name & "'!ShowUpdateSuccess"
 On Error GoTo 0
 Set wb = Nothing
 Set xl = Nothing
+If fso.FileExists(lockPath) Then fso.DeleteFile lockPath
 WScript.Quit 0
 
 Sub CleanUp()
   If Not wb Is Nothing Then wb.Close False
   If Not xl Is Nothing Then xl.Quit
+  If Not fso Is Nothing Then
+    If lockPath <> "" Then
+      If fso.FileExists(lockPath) Then fso.DeleteFile lockPath
+    End If
+  End If
 End Sub
+
+Function Download(url, path)
+  On Error Resume Next
+  Dim http, stream
+  Set http = CreateObject("MSXML2.XMLHTTP")
+  http.Open "GET", url, False
+  http.send
+  If http.Status = 200 Then
+    Set stream = CreateObject("ADODB.Stream")
+    stream.Type = 1
+    stream.Open
+    stream.Write http.responseBody
+    stream.SaveToFile path, 2
+    stream.Close
+    Download = True
+  Else
+    Download = False
+  End If
+  On Error GoTo 0
+End Function


### PR DESCRIPTION
## Summary
- Fetch update scripts and modules from SharePoint instead of local paths
- Prevent concurrent editing during updates via lock file and single-user checks
- Show update notes to each user only once after opening the workbook

## Testing
- ⚠️ `cscript //nologo vba_update.vbs` *(command not found: cscript)*

------
https://chatgpt.com/codex/tasks/task_e_689e81ea4ab48327b6c0719a715c3e8e